### PR TITLE
(Python) Close file descriptors

### DIFF
--- a/python/gherkin3/dialect.py
+++ b/python/gherkin3/dialect.py
@@ -1,14 +1,22 @@
+import io
 import os
 import json
 
 
+DIALECT_FILE_PATH = os.path.join(
+    os.path.dirname(__file__),
+    'gherkin-languages.json'
+    )
+
+with io.open(DIALECT_FILE_PATH, 'r') as file:
+    DIALECTS = json.load(file, encoding='utf-8')
+
+
 class Dialect(object):
-    DIALECTS = json.load(open(os.path.join(os.path.dirname(__file__),
-                                           'gherkin-languages.json'), 'r'), encoding='utf-8')
 
     @classmethod
     def for_name(cls, name):
-        return cls(cls.DIALECTS[name]) if name in cls.DIALECTS else None
+        return cls(DIALECTS[name]) if name in DIALECTS else None
 
     def __init__(self, spec):
         self.spec = spec

--- a/python/gherkin3/token_scanner.py
+++ b/python/gherkin3/token_scanner.py
@@ -1,27 +1,33 @@
+import io
 import os
 from .token import Token
 from .gherkin_line import GherkinLine
 try:
     python2 = True
     from cStringIO import StringIO
+    io.StringIO = StringIO
 except ImportError:
     python2 = False
-    from io import StringIO
 
 
 class TokenScanner(object):
-    def __init__(self, io):
-        if isinstance(io, str):
-            if os.path.exists(io):
-                self.io = open(io, 'rU')
+    def __init__(self, path_or_str):
+        if isinstance(path_or_str, str):
+            if os.path.exists(path_or_str):
+                self.io = io.open(path_or_str, 'rU')
             else:
-                self.io = StringIO(io)
+                self.io = io.StringIO(path_or_str)
         self.line_number = 0
 
     def read(self):
         self.line_number += 1
         location = {'line': self.line_number}
         line = self.io.readline()
-        if python2:
-            line = line.decode('utf-8')
         return Token((GherkinLine(line, self.line_number) if line else line), location)
+    
+    def __del__(self):
+        # close file descriptor if it's still open
+        try:
+            self.io.close()
+        except AttributeError:
+            pass


### PR DESCRIPTION
Also:
- Factor out `DIALECT_FILE_PATH` from `DIALECTS`
- Move `DIALECTS` from a class variable to a module variable

AFTER making these changes, I discovered a nearly line-for-line mirror of them in the Ruby implementation.  Knowing this, I named the `DIALECT_FILE_PATH` variable after its Ruby implementation equivalent (originally the variable was named something else).

So…happy accident. :-)
